### PR TITLE
Add support for USB/serial Port based RD-1212

### DIFF
--- a/src/cmd.py
+++ b/src/cmd.py
@@ -32,11 +32,14 @@ except:
 	import radexreader
 	msg = 'Information   radexreader ' + radexreader.__version__ + ' with python ' + python_version() + ' and pyusb ' + usb.__version__
 
-if len(sys.argv) > 1:
+port = ""
+if len(sys.argv) > 2 :
+		port = sys.argv[2]
 
+if len(sys.argv) > 1:
 	if sys.argv[1] == 'erase':
 		print(msg)
-		reader = radexreader.RadexReader()
+		reader = radexreader.RadexReader(port)
 		reader.print_info()
 		reader.erase()
 		print('done!')
@@ -44,7 +47,7 @@ if len(sys.argv) > 1:
 
 	if sys.argv[1] == 'tail':
 		print(msg)
-		reader = radexreader.RadexReader()
+		reader = radexreader.RadexReader(port)
 		reader.print_info()
 		prev = None
 		while True:
@@ -65,7 +68,7 @@ if len(sys.argv) > 1:
 
 	if sys.argv[1] == 'readlast':
 		print(msg)
-		reader = radexreader.RadexReader()
+		reader = radexreader.RadexReader(port)
 		reader.print_info()
 		measures = reader.read(True)
 		for timestamp, measure in measures.items():
@@ -83,8 +86,8 @@ if len(sys.argv) > 1:
 
 	if sys.argv[1] == 'readall':
 		print(msg)
-		reader = radexreader.RadexReader()
-		reader.print_info()
+		reader = radexreader.RadexReader(port)
+		#reader.print_info()
 		measures = reader.read(False)
 		for timestamp, measure in measures.items():
 			print("%s  %s µSv/h  ±%s%% (%s ≤ %s ≤ %s)" % (
@@ -101,13 +104,13 @@ if len(sys.argv) > 1:
 
 	if sys.argv[1] == 'jsonlast':
 		import json
-		print(json.dumps(radexreader.RadexReader().read(True)))
+		print(json.dumps(radexreader.RadexReader(port).read(True)))
 		exit(0)
 
 	if sys.argv[1] == 'jsonall':
 		import json
-		print(json.dumps(radexreader.RadexReader().read(False)))
+		print(json.dumps(radexreader.RadexReader(port).read(False)))
 		exit(0)
 
-print('Usage: radexreader erase|tail|readlast|readall|jsonlast|jsonall')
+print('Usage: radexreader erase|tail|readlast|readall|jsonlast|jsonall [COMPORT]')
 exit(-1)

--- a/src/radexreader/__init__.py
+++ b/src/radexreader/__init__.py
@@ -22,32 +22,47 @@ import usb.core
 import usb.util
 import usb.backend.libusb1
 import operator
+import serial
+import time
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
-class RadexReader():
-
+class RadexReader(object):
+	device ="usb"
 	dev = None
-
-	def __init__(self):
+	ser = None
+	def __init__(self,serport):
 		# search (backend only? for alpine with docker)
 		backend  = usb.backend.libusb1.get_backend(find_library=lambda x: "/usr/lib/libusb-1.0.so.0")
-		self.dev = usb.core.find(idVendor=0x03eb, idProduct=0x5603, backend=backend)
+		self.dev = usb.core.find(idVendor=0x03eb , idProduct=0x5603, backend=backend)
 		# check
 		if self.dev is None:
-			raise ValueError('Error: RADEX RD1212 not plugged?')
-		# reset
-		self.dev.reset()
-		if sys.platform != 'win32' and sys.platform != 'cygwin' and self.dev.is_kernel_driver_active(0):
-			self.dev.detach_kernel_driver(0)
-		self.dev.set_configuration()
+			if (serport == ""):
+				raise ValueError('Error: RADEX RD1212 not found on USB and no Serialport given')
+
+			# must be a serial device then
+			self.device ="serial"
+		
+			self.ser = serial.Serial(port = serport, baudrate = 115200, timeout = 0.5)
+			if self.ser is None:
+				raise ValueError('Error: RADEX RD1212 Serialport NOT availavble')	
+			# reset
+		else:
+			self.dev.reset()
+			if sys.platform != 'win32' and sys.platform != 'cygwin' and self.dev.is_kernel_driver_active(0):
+				self.dev.detach_kernel_driver(0)
+			self.dev.set_configuration()
 
 	def get_device(self):
 		return self.dev
 
 	def print_info(self):
-		print('Manufacturer  ' + hex(self.dev.idVendor).ljust(7, ' ')  + ' ' + usb.util.get_string(self.dev, self.dev.iManufacturer))
-		print('Product       ' + hex(self.dev.idProduct).ljust(7, ' ') + ' ' + usb.util.get_string(self.dev, self.dev.iProduct))
+		if self.device=="usb":
+			print('Manufacturer  ' + hex(self.dev.idVendor).ljust(7, ' ')  + ' ' + usb.util.get_string(self.dev, self.dev.iManufacturer))
+			print('Product       ' + hex(self.dev.idProduct).ljust(7, ' ') + ' ' + usb.util.get_string(self.dev, self.dev.iProduct))
+		else:
+			print('ComPort       ' + self.ser.port)
+
 		print()
 		print('[info] Sensor: Geiger-Müller tube SBM 20-1')
 		print('[info] Measuring range: 0.05 - 999 µSv/h')
@@ -62,23 +77,30 @@ class RadexReader():
 
 	def hid_set_report(self, report):
 		# https://stackoverflow.com/a/52368526/2980105
-		self.dev.ctrl_transfer(
-			0x21,  # REQUEST_TYPE_CLASS | RECIPIENT_INTERFACE | ENDPOINT_OUT
-			9,     # SET_REPORT
-			0x300, # Vendor Descriptor Type + 0 Descriptor Index
-			0,     # USB interface #0
-			report # the HID payload as a byte array
-		)
+		if self.device == "usb":
+			self.dev.ctrl_transfer(
+				0x21,  # REQUEST_TYPE_CLASS | RECIPIENT_INTERFACE | ENDPOINT_OUT
+				9,     # SET_REPORT
+				0x300, # Vendor Descriptor Type + 0 Descriptor Index
+				0,     # USB interface #0
+				report # the HID payload as a byte array
+			)
+		else:
+			self.ser.write(report)
 
 	def hid_get_report(self):
 		# https://stackoverflow.com/a/52368526/2980105
-		return self.dev.ctrl_transfer(
-			0xA1,  # REQUEST_TYPE_CLASS | RECIPIENT_INTERFACE | ENDPOINT_IN
-			1,     # GET_REPORT
-			0x300, # Vendor Descriptor Type + 0 Descriptor Index
-			0,     # USB interface #0
-			64     # max reply size
-		)
+		if self.device == "usb":
+			return self.dev.ctrl_transfer(
+				0xA1,  # REQUEST_TYPE_CLASS | RECIPIENT_INTERFACE | ENDPOINT_IN
+				1,     # GET_REPORT
+				0x300, # Vendor Descriptor Type + 0 Descriptor Index
+				0,     # USB interface #0
+				64     # max reply size
+			)
+		else:
+			result = self.ser.read(14)
+			return result
 
 	def serial_number(self):
 		# serial number?
@@ -86,6 +108,7 @@ class RadexReader():
 		print(self.hid_get_report())
 		self.hid_set_report((0x12, 0x12, 0x01, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0x3c, 0x84))
 		print(self.hid_get_report())
+
 
 	def erase(self):
 		self.hid_set_report((0x12, 0x12, 0x01, 0, 0, 0, 0, 0, 0x02, 0x04, 0, 0x24, 0x01, 0))
@@ -102,6 +125,38 @@ class RadexReader():
 
 		for key in keys:
 			self.hid_set_report((0x12, 0x12, 0x01, 0x02, key, 0, 0, 0, 0, 0, 0, 0, 0x3c, 0x84))
+			hexa = self.hid_get_report()
+
+			#
+			
+			if hexa[0] != 0:
+				# timestamp - 01/01/2016 00:00:44 = 1451606444
+				# device    - 01/01/2016 00:00:44 = 172 193 133 86
+				timestamp   = hexa[2] + hexa[3] * 256 + hexa[4] * 256 * 256 + hexa[5] * 256 * 256 * 256
+				# measure   - 0.15 µSv/h = 15
+				measure     = (hexa[6] + hexa[7] * 256 + hexa[8] * 256 * 256) / 100
+				# uncertainty of the result
+				percent     = 15 + 6 / measure
+				measure_min = measure * (1 - percent / 100)
+				measure_max = measure * (1 + percent / 100)
+				if measure_min < 0:
+					measure_min = 0
+				# memorize
+				values[timestamp] = { 'pct': percent, 'min': measure_min, 'val': measure, 'max': measure_max }
+
+		# sort by date
+		return dict(sorted(values.items(), key=operator.itemgetter(0)))
+
+	def readOLD(self, last=False):
+
+		values = {}
+		if last:
+			keys = [0x0]
+		else:
+			keys = list(range(0x0, 0xb4)) # from 0x0 to 0xb3
+
+		for key in keys:
+			self.hid_set_report((0x12, 0x12, 0x01, 0x02, key, 0, 0, 0, 0, 0, 0, 0, 0, 0))
 			hexa = self.hid_get_report()
 			if hexa[0] != 0:
 				# timestamp - 01/01/2016 00:00:44 = 1451606444


### PR DESCRIPTION
Adding support for the versions of RD-1212 which are not accessible as an USB device but as an RS232 port (utilizing an integrated USB/UART bridge).

Open issue: Would be nice to find a way to determine the port / device automatically.